### PR TITLE
Add option to allow loading very large images

### DIFF
--- a/src/split_image/split.py
+++ b/src/split_image/split.py
@@ -97,8 +97,12 @@ def main():
                         help="Reverse the splitting process, i.e. merge multiple tiles of an image into one.")
     parser.add_argument("--cleanup", action="store_true",
                         help="After splitting or merging, delete the original image/images.")
+    parser.add_argument("--load-large-images", action="store_true",
+                        help="Ignore the PIL decompression bomb protection and load all large files.")
     args = parser.parse_args()
     image_path = args.image_path[0]
+    if args.load_large_images:
+        Image.MAX_IMAGE_PIXELS = None
     if args.reverse:
         print(
             "Reverse mode selected! Will try to merge multiple tiles of an image into one.")


### PR DESCRIPTION
I was using your (very awesome btw) tool on some... well.... large images. So large, that [PIL threw an error](https://pillow.readthedocs.io/en/stable/reference/Image.html#functionsl):
```
PIL.Image.DecompressionBombError: Image size (640608150 pixels) exceeds limit of 178956970 pixels, could be decompression bomb DOS attack.
```

This PR introduces the `--load-large-images` flag to avoid this.

Hope this helps and you do not mind increasing the LOC counter ;)

Cheers, Paul